### PR TITLE
Enforce 11-digit phones and standardize uppercase + amount formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@ Admin dashboard for managing billing records from a Google Sheet export.
 ## Features
 - SQLite-backed records
 - Signup/Signin with phone + 4-digit PIN
+- OTP-based signup verification and PIN reset flow
+- PIN policy + signin lockout controls + auth event logging
 - Session login with role-based routing (`admin`, `encoder`, or `customer`)
 - Server-side DataTables endpoint (search, sort, pagination)
 - Filters: biller, transaction date range, due status
@@ -13,6 +15,10 @@ Admin dashboard for managing billing records from a Google Sheet export.
 - Duplicate detection by `txn_date + account + biller + amount` (create, update, import)
 - Auto-generated unique reference code when missing
 - Validation guards for due date and amount before save
+- Phone validation: exactly 11 digits
+- CP number validation: exactly 11 digits when provided
+- Text normalization: form text values are standardized to uppercase before persistence
+- Amount display formatting: comma separators with 2 decimal places on key views
 
 ## Run
 ```bash
@@ -22,7 +28,7 @@ pip install -r requirements.txt
 uvicorn main:app --reload
 ```
 
-Open: `http://127.0.0.1:8000/admin/records`
+Open: `http://127.0.0.1:8000/auth/signin`
 
 ### Windows (PowerShell) quickstart
 ```powershell

--- a/app/auth.py
+++ b/app/auth.py
@@ -17,7 +17,7 @@ def normalize_phone(phone: str) -> str:
 
 
 def validate_phone(phone: str) -> bool:
-    return 10 <= len(phone) <= 15
+    return phone.isdigit() and len(phone) == 11
 
 
 def validate_pin(pin: str) -> bool:

--- a/app/controllers/bill_controller.py
+++ b/app/controllers/bill_controller.py
@@ -82,7 +82,7 @@ def _normalized_amount(payload: dict) -> float:
 
 
 def _normalize_text_fields(payload: dict) -> dict:
-    for key in ("account", "biller", "customer_name", "cp_number", "reference"):
+    for key in ("account", "biller", "customer_name", "cp_number", "reference", "notes"):
         value = payload.get(key)
         if value is None:
             continue

--- a/app/database.py
+++ b/app/database.py
@@ -87,3 +87,43 @@ async def init_db() -> None:
             )
         if "locked_until" not in user_col_names:
             await conn.execute(text("ALTER TABLE user_accounts ADD COLUMN locked_until DATETIME"))
+
+        # Data normalization: keep form text fields uppercase in existing rows.
+        await conn.execute(
+            text(
+                """
+                UPDATE user_accounts
+                SET
+                    first_name = UPPER(TRIM(first_name)),
+                    last_name = UPPER(TRIM(last_name))
+                """
+            )
+        )
+        await conn.execute(
+            text(
+                """
+                UPDATE business_profiles
+                SET
+                    business_name = UPPER(TRIM(business_name)),
+                    business_address = UPPER(TRIM(business_address)),
+                    business_phone = CASE WHEN business_phone IS NULL THEN NULL ELSE UPPER(TRIM(business_phone)) END,
+                    business_email = CASE WHEN business_email IS NULL THEN NULL ELSE UPPER(TRIM(business_email)) END,
+                    tin_number = CASE WHEN tin_number IS NULL THEN NULL ELSE UPPER(TRIM(tin_number)) END,
+                    receipt_footer = CASE WHEN receipt_footer IS NULL THEN NULL ELSE UPPER(TRIM(receipt_footer)) END
+                """
+            )
+        )
+        await conn.execute(
+            text(
+                """
+                UPDATE bill_records
+                SET
+                    account = UPPER(TRIM(account)),
+                    biller = UPPER(TRIM(biller)),
+                    customer_name = UPPER(TRIM(customer_name)),
+                    cp_number = UPPER(TRIM(cp_number)),
+                    notes = CASE WHEN notes IS NULL THEN NULL ELSE UPPER(TRIM(notes)) END,
+                    reference = CASE WHEN reference IS NULL THEN NULL ELSE UPPER(TRIM(reference)) END
+                """
+            )
+        )

--- a/app/models/user_account.py
+++ b/app/models/user_account.py
@@ -10,7 +10,7 @@ class UserAccount(SQLModel, table=True):
     id: Optional[int] = Field(default=None, primary_key=True)
     first_name: str = Field(max_length=80)
     last_name: str = Field(max_length=80)
-    phone: str = Field(max_length=20, index=True, unique=True)
+    phone: str = Field(max_length=11, index=True, unique=True)
     pin_hash: str = Field(max_length=128)
     pin_salt: str = Field(max_length=64)
     role: str = Field(default="customer", max_length=20, index=True)

--- a/app/routes/auth_routes.py
+++ b/app/routes/auth_routes.py
@@ -28,6 +28,10 @@ PIN_MAX_FAILED_ATTEMPTS = int(os.getenv("PIN_MAX_FAILED_ATTEMPTS", "5"))
 PIN_LOCKOUT_MINUTES = int(os.getenv("PIN_LOCKOUT_MINUTES", "15"))
 
 
+def _normalize_text(value: str) -> str:
+    return value.strip().upper()
+
+
 def _render_signup(
     request: Request,
     error: Optional[str] = None,
@@ -246,8 +250,8 @@ async def signup_submit(
     pin_confirm: str = Form(...),
     db: AsyncSession = Depends(get_db),
 ):
-    cleaned_first = first_name.strip()
-    cleaned_last = last_name.strip()
+    cleaned_first = _normalize_text(first_name)
+    cleaned_last = _normalize_text(last_name)
     normalized_phone = normalize_phone(phone)
 
     if not cleaned_first or not cleaned_last:
@@ -623,11 +627,11 @@ async def admin_signup_submit(
     if await _has_admin_account(db):
         return RedirectResponse(url="/auth/signin", status_code=303)
 
-    cleaned_first = first_name.strip()
-    cleaned_last = last_name.strip()
+    cleaned_first = _normalize_text(first_name)
+    cleaned_last = _normalize_text(last_name)
     normalized_phone = normalize_phone(phone)
-    cleaned_business_name = business_name.strip()
-    cleaned_business_address = business_address.strip()
+    cleaned_business_name = _normalize_text(business_name)
+    cleaned_business_address = _normalize_text(business_address)
 
     if not cleaned_first or not cleaned_last:
         return _render_admin_signup(
@@ -705,10 +709,10 @@ async def admin_signup_submit(
         admin_user_id=user.id,
         business_name=cleaned_business_name,
         business_address=cleaned_business_address,
-        business_phone=business_phone.strip() or None,
-        business_email=business_email.strip() or None,
-        tin_number=tin_number.strip() or None,
-        receipt_footer=receipt_footer.strip() or None,
+        business_phone=_normalize_text(business_phone) or None,
+        business_email=_normalize_text(business_email) or None,
+        tin_number=_normalize_text(tin_number) or None,
+        receipt_footer=_normalize_text(receipt_footer) or None,
     )
     db.add(profile)
 

--- a/app/routes/bill_routes.py
+++ b/app/routes/bill_routes.py
@@ -50,6 +50,10 @@ RECEIPT_FIELD_KEYS = (
 )
 
 
+def _normalize_text(value: str) -> str:
+    return value.strip().upper()
+
+
 class RecordCreate(BaseModel):
     txn_datetime: Optional[datetime] = None
     txn_date: Optional[date] = None
@@ -95,7 +99,7 @@ class RecordResponse(RecordCreate):
 class AdminUserCreate(BaseModel):
     first_name: str = Field(min_length=1, max_length=80)
     last_name: str = Field(min_length=1, max_length=80)
-    phone: str = Field(min_length=1, max_length=20)
+    phone: str = Field(min_length=11, max_length=11)
     pin: str = Field(min_length=4, max_length=4)
     role: str = Field(min_length=1, max_length=20)
 
@@ -223,8 +227,8 @@ async def update_business_settings(
     db: AsyncSession = Depends(get_db),
     current_user: UserAccount = Depends(require_admin),
 ):
-    cleaned_name = business_name.strip()
-    cleaned_address = business_address.strip()
+    cleaned_name = _normalize_text(business_name)
+    cleaned_address = _normalize_text(business_address)
     if not cleaned_name:
         return RedirectResponse(url="/admin/settings?error=Business+name+is+required", status_code=303)
     if not cleaned_address:
@@ -236,10 +240,10 @@ async def update_business_settings(
             admin_user_id=current_user.id,
             business_name=cleaned_name,
             business_address=cleaned_address,
-            business_phone=business_phone.strip() or None,
-            business_email=business_email.strip() or None,
-            tin_number=tin_number.strip() or None,
-            receipt_footer=receipt_footer.strip() or None,
+            business_phone=_normalize_text(business_phone) or None,
+            business_email=_normalize_text(business_email) or None,
+            tin_number=_normalize_text(tin_number) or None,
+            receipt_footer=_normalize_text(receipt_footer) or None,
             receipt_show_headings=receipt_show_headings is not None,
             receipt_visible_fields=_serialize_visible_fields(list(RECEIPT_FIELD_KEYS)),
             receipt_show_business_name=receipt_show_business_name is not None,
@@ -251,10 +255,10 @@ async def update_business_settings(
     else:
         profile.business_name = cleaned_name
         profile.business_address = cleaned_address
-        profile.business_phone = business_phone.strip() or None
-        profile.business_email = business_email.strip() or None
-        profile.tin_number = tin_number.strip() or None
-        profile.receipt_footer = receipt_footer.strip() or None
+        profile.business_phone = _normalize_text(business_phone) or None
+        profile.business_email = _normalize_text(business_email) or None
+        profile.tin_number = _normalize_text(tin_number) or None
+        profile.receipt_footer = _normalize_text(receipt_footer) or None
         profile.receipt_show_headings = receipt_show_headings is not None
         profile.receipt_visible_fields = _serialize_visible_fields(list(RECEIPT_FIELD_KEYS))
         profile.receipt_show_business_name = receipt_show_business_name is not None
@@ -278,8 +282,8 @@ async def create_encoder_user(
     db: AsyncSession = Depends(get_db),
     _: UserAccount = Depends(require_admin),
 ):
-    cleaned_first = first_name.strip()
-    cleaned_last = last_name.strip()
+    cleaned_first = _normalize_text(first_name)
+    cleaned_last = _normalize_text(last_name)
     normalized_phone = normalize_phone(phone)
 
     if not cleaned_first or not cleaned_last:
@@ -448,8 +452,8 @@ async def upsert_user(
     if not pin_ok:
         raise HTTPException(status_code=400, detail=pin_error or "Invalid PIN")
 
-    first_name = payload.first_name.strip()
-    last_name = payload.last_name.strip()
+    first_name = _normalize_text(payload.first_name)
+    last_name = _normalize_text(payload.last_name)
     if not first_name or not last_name:
         raise HTTPException(status_code=400, detail="First name and last name are required")
 

--- a/app/routes/bill_routes.py
+++ b/app/routes/bill_routes.py
@@ -54,13 +54,22 @@ def _normalize_text(value: str) -> str:
     return value.strip().upper()
 
 
+def _is_valid_cp_number(value: Optional[str]) -> bool:
+    if value is None:
+        return True
+    cleaned = str(value).strip()
+    if cleaned == "":
+        return True
+    return cleaned.isdigit() and len(cleaned) == 11
+
+
 class RecordCreate(BaseModel):
     txn_datetime: Optional[datetime] = None
     txn_date: Optional[date] = None
     account: str = Field(min_length=1, max_length=64)
     biller: str = Field(min_length=1, max_length=120)
     customer_name: str = Field(min_length=1, max_length=160)
-    cp_number: str = ""
+    cp_number: str = Field(default="", max_length=11)
     bill_amt: float = 0
     amt2: float = 0
     charge: float = 0
@@ -78,7 +87,7 @@ class RecordUpdate(BaseModel):
     account: Optional[str] = Field(default=None, min_length=1, max_length=64)
     biller: Optional[str] = Field(default=None, min_length=1, max_length=120)
     customer_name: Optional[str] = Field(default=None, min_length=1, max_length=160)
-    cp_number: Optional[str] = None
+    cp_number: Optional[str] = Field(default=None, max_length=11)
     bill_amt: Optional[float] = None
     amt2: Optional[float] = None
     charge: Optional[float] = None
@@ -560,6 +569,8 @@ async def create_record_endpoint(
 
     if payload.bill_amt <= 0:
         raise HTTPException(status_code=400, detail="Bill amount is required")
+    if not _is_valid_cp_number(payload.cp_number):
+        raise HTTPException(status_code=400, detail="CP number must be exactly 11 digits")
 
     record = await create_record(db, payload.model_dump())
     return record
@@ -578,6 +589,8 @@ async def update_record_endpoint(
 
     if "due_date" in updates and updates["due_date"] is None:
         raise HTTPException(status_code=400, detail="Due date is required")
+    if "cp_number" in updates and not _is_valid_cp_number(updates.get("cp_number")):
+        raise HTTPException(status_code=400, detail="CP number must be exactly 11 digits")
 
     record = await update_record(db, record_id, updates)
     return record

--- a/app/static/css/app.css
+++ b/app/static/css/app.css
@@ -121,6 +121,12 @@ select, input, textarea {
     width: 100%;
 }
 
+input[type="text"],
+input[type="email"],
+textarea {
+    text-transform: uppercase;
+}
+
 .btn {
     border: 1px solid var(--border);
     border-radius: 10px;
@@ -200,6 +206,17 @@ a.btn { text-decoration: none; display: inline-flex; align-items: center; }
 
 .form-grid .full {
     grid-column: 1 / -1;
+}
+
+.amount-emphasis {
+    font-size: 0.98rem;
+    font-weight: 800;
+}
+
+.amount-emphasis input {
+    font-size: 1.08rem;
+    font-weight: 800;
+    letter-spacing: 0.2px;
 }
 
 .form-grid-pro {

--- a/app/static/js/app.js
+++ b/app/static/js/app.js
@@ -1,0 +1,35 @@
+function sanitizePhoneInput(el) {
+    if (!el) {
+        return;
+    }
+    const digits = String(el.value || "").replace(/\D/g, "").slice(0, 11);
+    if (el.value !== digits) {
+        el.value = digits;
+    }
+}
+
+function uppercaseTextInput(el) {
+    if (!el) {
+        return;
+    }
+    const upper = String(el.value || "").toUpperCase();
+    if (el.value !== upper) {
+        el.value = upper;
+    }
+}
+
+document.addEventListener("input", (event) => {
+    const target = event.target;
+    if (!(target instanceof HTMLInputElement || target instanceof HTMLTextAreaElement)) {
+        return;
+    }
+
+    if (target instanceof HTMLInputElement && target.type === "tel") {
+        sanitizePhoneInput(target);
+        return;
+    }
+
+    if (target instanceof HTMLTextAreaElement || target.type === "text" || target.type === "email") {
+        uppercaseTextInput(target);
+    }
+});

--- a/app/static/js/entry_form.js
+++ b/app/static/js/entry_form.js
@@ -157,6 +157,10 @@ function validatePayload(payload) {
         alert("ACCOUNT, BILLER, AND NAME ARE REQUIRED");
         return false;
     }
+    if (payload.cp_number && !/^\d{11}$/.test(payload.cp_number)) {
+        alert("CP NUMBER MUST BE EXACTLY 11 DIGITS");
+        return false;
+    }
     if (!payload.due_date) {
         alert("DUE DATE IS REQUIRED");
         return false;

--- a/app/static/js/entry_form.js
+++ b/app/static/js/entry_form.js
@@ -7,6 +7,11 @@ function round2(value) {
     return Math.round((parseNum(value) + Number.EPSILON) * 100) / 100;
 }
 
+function formatMoney(value) {
+    const num = round2(value);
+    return num.toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 });
+}
+
 const BILLER_CHARGES = window.BILLER_CHARGES || {};
 const BILLER_LATE_CHARGES = window.BILLER_LATE_CHARGES || {};
 let lastSavedRecordId = null;
@@ -175,12 +180,12 @@ function confirmDetails(payload) {
         ["NAME", payload.customer_name],
         ["CP NUMBER", payload.cp_number || "-"],
         ["DUE DATE", payload.due_date || "-"],
-        ["BILL AMOUNT", payload.bill_amt.toFixed(2)],
-        ["LATE CHARGE", payload.amt2.toFixed(2)],
-        ["SERVICE CHARGE", payload.charge.toFixed(2)],
-        ["TOTAL", payload.total.toFixed(2)],
-        ["CASH", payload.cash.toFixed(2)],
-        ["CHANGE", payload.change_amt.toFixed(2)],
+        ["BILL AMOUNT", formatMoney(payload.bill_amt)],
+        ["LATE CHARGE", formatMoney(payload.amt2)],
+        ["SERVICE CHARGE", formatMoney(payload.charge)],
+        ["TOTAL", formatMoney(payload.total)],
+        ["CASH", formatMoney(payload.cash)],
+        ["CHANGE", formatMoney(payload.change_amt)],
     ];
 
     dom.confirmSummary.innerHTML = rows

--- a/app/static/js/records.js
+++ b/app/static/js/records.js
@@ -462,6 +462,11 @@ function validatePayload(payload) {
         return false;
     }
 
+    if (payload.cp_number && !/^\d{11}$/.test(payload.cp_number)) {
+        showMessage("CP number must be exactly 11 digits.", "Validation");
+        return false;
+    }
+
     if (!payload.account) {
         showMessage("Account is required.", "Validation");
         return false;

--- a/app/templates/admin_signup.html
+++ b/app/templates/admin_signup.html
@@ -22,7 +22,7 @@
             <input type="text" name="last_name" value="{{ last_name }}" required maxlength="80">
         </label>
         <label>Phone Number
-            <input type="tel" name="phone" value="{{ phone }}" required maxlength="20" placeholder="09XXXXXXXXX">
+            <input type="tel" name="phone" value="{{ phone }}" required minlength="11" maxlength="11" inputmode="numeric" pattern="\d{11}" placeholder="09XXXXXXXXX">
         </label>
         <label>4-digit PIN
             <input type="password" name="pin" required minlength="4" maxlength="4" inputmode="numeric" pattern="\d{4}">

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -53,6 +53,7 @@
 
     <script src="https://code.jquery.com/jquery-3.7.1.min.js"></script>
     <script src="https://cdn.datatables.net/2.0.8/js/dataTables.min.js"></script>
+    <script src="/static/js/app.js"></script>
     {% block scripts %}{% endblock %}
 </body>
 </html>

--- a/app/templates/entry_form.html
+++ b/app/templates/entry_form.html
@@ -36,7 +36,7 @@
             <label>Account<input type="text" id="account" required></label>
             <label>Biller<input type="text" id="biller" list="billerOptions" required></label>
             <label>Name<input type="text" id="customerName" required></label>
-            <label>CP Number<input type="text" id="cpNumber"></label>
+            <label>CP Number<input type="tel" id="cpNumber" minlength="11" maxlength="11" inputmode="numeric" pattern="\d{11}" placeholder="09XXXXXXXXX"></label>
             <label>Due Date<input type="date" id="dueDate" required></label>
         </div>
 

--- a/app/templates/entry_form.html
+++ b/app/templates/entry_form.html
@@ -45,8 +45,8 @@
             <label>Service Charge<input type="number" step="0.01" id="charge" readonly></label>
             <label>Late Charge<input type="number" step="0.01" id="amt2" readonly></label>
             <label>Cash<input type="number" step="0.01" id="cash" min="0"></label>
-            <label>Total<input type="number" step="0.01" id="total" readonly></label>
-            <label>Change<input type="number" step="0.01" id="changeAmt" readonly></label>
+            <label class="amount-emphasis">Total<input type="number" step="0.01" id="total" readonly></label>
+            <label class="amount-emphasis">Change<input type="number" step="0.01" id="changeAmt" readonly></label>
         </div>
 
         <div class="dialog-actions entry-actions">

--- a/app/templates/receipt.html
+++ b/app/templates/receipt.html
@@ -145,37 +145,37 @@
         {% if receipt_settings.show_bill_amt %}
         <div class="line">
             <span>{% if receipt_settings.show_headings %}BILL AMOUNT{% endif %}</span>
-            <span>{{ "%.2f"|format(record.bill_amt) }}</span>
+            <span>{{ "{:,.2f}".format(record.bill_amt) }}</span>
         </div>
         {% endif %}
         {% if receipt_settings.show_amt2 %}
         <div class="line">
             <span>{% if receipt_settings.show_headings %}LATE CHARGE{% endif %}</span>
-            <span>{{ "%.2f"|format(record.amt2) }}</span>
+            <span>{{ "{:,.2f}".format(record.amt2) }}</span>
         </div>
         {% endif %}
         {% if receipt_settings.show_charge %}
         <div class="line">
             <span>{% if receipt_settings.show_headings %}SERVICE CHARGE{% endif %}</span>
-            <span>{{ "%.2f"|format(record.charge) }}</span>
+            <span>{{ "{:,.2f}".format(record.charge) }}</span>
         </div>
         {% endif %}
         {% if receipt_settings.show_total %}
         <div class="line total">
             <span>{% if receipt_settings.show_headings %}TOTAL{% endif %}</span>
-            <span>{{ "%.2f"|format(record.total) }}</span>
+            <span>{{ "{:,.2f}".format(record.total) }}</span>
         </div>
         {% endif %}
         {% if receipt_settings.show_cash %}
         <div class="line">
             <span>{% if receipt_settings.show_headings %}CASH{% endif %}</span>
-            <span>{{ "%.2f"|format(record.cash) }}</span>
+            <span>{{ "{:,.2f}".format(record.cash) }}</span>
         </div>
         {% endif %}
         {% if receipt_settings.show_change_amt %}
         <div class="line">
             <span>{% if receipt_settings.show_headings %}CHANGE{% endif %}</span>
-            <span>{{ "%.2f"|format(record.change_amt) }}</span>
+            <span>{{ "{:,.2f}".format(record.change_amt) }}</span>
         </div>
         {% endif %}
         <div class="sign">

--- a/app/templates/records.html
+++ b/app/templates/records.html
@@ -168,7 +168,7 @@
             <label>Account<input type="text" id="account" required></label>
             <label>Biller<input type="text" id="biller" list="billerOptions" required></label>
             <label>Name<input type="text" id="customerName" required></label>
-            <label>CP Number<input type="text" id="cpNumber"></label>
+            <label>CP Number<input type="tel" id="cpNumber" minlength="11" maxlength="11" inputmode="numeric" pattern="\d{11}" placeholder="09XXXXXXXXX"></label>
             <label>Due Date<input type="date" id="dueDate" required></label>
             <label>Bill Amount<input type="number" step="0.01" id="billAmt" value="0" min="0"></label>
             <label>Late Charge<input type="number" step="0.01" id="amt2" value="0" min="0"></label>

--- a/app/templates/records.html
+++ b/app/templates/records.html
@@ -121,7 +121,7 @@
             <input type="text" id="addUserLastName" required maxlength="80">
         </label>
         <label>Phone Number
-            <input type="tel" id="addUserPhone" required maxlength="20" placeholder="09XXXXXXXXX">
+            <input type="tel" id="addUserPhone" required minlength="11" maxlength="11" inputmode="numeric" pattern="\d{11}" placeholder="09XXXXXXXXX">
         </label>
         <label>4-digit PIN
             <input type="password" id="addUserPin" required minlength="4" maxlength="4" inputmode="numeric" pattern="\d{4}">
@@ -173,9 +173,9 @@
             <label>Bill Amount<input type="number" step="0.01" id="billAmt" value="0" min="0"></label>
             <label>Late Charge<input type="number" step="0.01" id="amt2" value="0" min="0"></label>
             <label>Service Charge<input type="number" step="0.01" id="charge" value="0" readonly></label>
-            <label>Total<input type="number" step="0.01" id="total" value="0" readonly></label>
+            <label class="amount-emphasis">Total<input type="number" step="0.01" id="total" value="0" readonly></label>
             <label>Cash<input type="number" step="0.01" id="cash" value="0" min="0"></label>
-            <label>Change<input type="number" step="0.01" id="changeAmt" value="0" readonly></label>
+            <label class="amount-emphasis">Change<input type="number" step="0.01" id="changeAmt" value="0" readonly></label>
             <label>Reference<input type="text" id="reference" placeholder="Auto-generate if blank"></label>
             <label class="full">Notes<textarea id="notes" rows="2"></textarea></label>
         </div>

--- a/app/templates/signin.html
+++ b/app/templates/signin.html
@@ -22,7 +22,7 @@
 
     <form method="post" action="/auth/signin" class="auth-form">
         <label>Phone Number
-            <input type="tel" name="phone" value="{{ phone }}" required maxlength="20" placeholder="09XXXXXXXXX">
+            <input type="tel" name="phone" value="{{ phone }}" required minlength="11" maxlength="11" inputmode="numeric" pattern="\d{11}" placeholder="09XXXXXXXXX">
         </label>
         <label>4-digit PIN
             <input type="password" name="pin" required minlength="4" maxlength="4" inputmode="numeric" pattern="\d{4}">

--- a/app/templates/signup.html
+++ b/app/templates/signup.html
@@ -25,7 +25,7 @@
             <input type="text" name="last_name" value="{{ last_name }}" required maxlength="80">
         </label>
         <label>Phone Number
-            <input type="tel" name="phone" value="{{ phone }}" required maxlength="20" placeholder="09XXXXXXXXX">
+            <input type="tel" name="phone" value="{{ phone }}" required minlength="11" maxlength="11" inputmode="numeric" pattern="\d{11}" placeholder="09XXXXXXXXX">
         </label>
         <label>4-digit PIN
             <input type="password" name="pin" required minlength="4" maxlength="4" inputmode="numeric" pattern="\d{4}">

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -10,7 +10,7 @@
   - [x] BPS-201.6 Signin controls: add failed-attempt counter and temporary lockout after threshold
   - [x] BPS-201.7 Recovery flow: add PIN reset request + OTP confirm + new PIN set
   - [x] BPS-201.8 Auth logging: log signin success/failure, lockout events, OTP verify events
-  - [ ] BPS-201.9 UI updates: signup/signin templates show OTP and lockout states with clear errors
+  - [x] BPS-201.9 UI updates: signup/signin templates show OTP and lockout states with clear errors
   - [ ] BPS-201.10 Verification: manual test matrix for happy path, invalid OTP, expired OTP, lockout, reset flow
 - [ ] BPS-202 | Theme: Reliability | Outcome: Add transaction audit log (`who`, `when`, `channel`, `status`) | Done when: each record state change writes an audit entry and is viewable in admin
 - [ ] BPS-203 | Theme: Validation | Outcome: Strengthen counter payment validation by biller rules | Done when: required fields/format are enforced per biller before save

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -17,7 +17,7 @@ Track meaningful technical and product decisions so future changes stay consiste
 
 - Date: 2026-03-07
 - ID: DEC-001
-- Related task: BPS-130
+- Related task: N/A (Process)
 - Decision: Standardize workflow around docs-based backlog + decision log + PowerShell helper script.
 - Why: Keep planning and delivery consistent without introducing heavyweight tooling.
 - Alternatives considered: external PM tools only, ad-hoc TODO files.
@@ -30,3 +30,19 @@ Track meaningful technical and product decisions so future changes stay consiste
 - Why: The PDF captures business intent, risks, and sequencing better than generic placeholders.
 - Alternatives considered: continue with placeholder backlog, or prioritize by technical ease only.
 - Follow-up: Re-rank `NOW/NEXT/LATER` every Friday based on incident risk, reconciliation impact, and operational speed.
+
+- Date: 2026-03-09
+- ID: DEC-003
+- Related task: BPS-203
+- Decision: Enforce strict numeric length rules for identity/contact inputs (`phone` and optional `cp_number`) with both frontend and backend validation.
+- Why: Prevent invalid data at source and avoid inconsistent records caused by client-side bypasses.
+- Alternatives considered: frontend-only validation, backend-only validation.
+- Follow-up: Keep templates, JS validators, and API models aligned whenever field rules change.
+
+- Date: 2026-03-09
+- ID: DEC-004
+- Related task: BPS-203
+- Decision: Standardize text-form input persistence to uppercase and normalize existing DB rows during init.
+- Why: Improve data consistency for search, reporting, and receipt output.
+- Alternatives considered: preserve input casing, normalize only at display time.
+- Follow-up: Ensure new text fields are included in normalization rules.

--- a/docs/WORKFLOW.md
+++ b/docs/WORKFLOW.md
@@ -53,7 +53,14 @@ A task is done only if:
 4. `./scripts/dev.ps1 check` passes
 5. `docs/BACKLOG.md` and `docs/DECISIONS.md` are updated
 
-## 6) Weekly Cadence
+## 6) Current Standards
+Unless explicitly overridden by a task requirement:
+1. Phone fields must enforce exactly 11 digits.
+2. CP number must enforce exactly 11 digits when provided.
+3. Text form values are normalized to uppercase before persistence.
+4. Amount displays should use comma separators with 2 decimal places on summaries/receipts/tables.
+
+## 7) Weekly Cadence
 1. Monday: pick top `NOW` items from backlog
 2. Mid-week: close blockers, update decisions
 3. Friday: move completed tasks to `DONE`, re-rank `NEXT`


### PR DESCRIPTION
## Summary
- Enforced phone numbers to exactly 11 digits (frontend + backend validation).
- Standardized text inputs to uppercase across forms and server-side normalization.
- Added DB normalization on init for existing text data (user, business profile, bill records).
- Improved amount display readability:
  - Comma-separated with 2 decimals in receipt and entry confirmation.
  - Emphasized TOTAL and CHANGE fields (larger, bolder).
- Synced project docs with current implementation (README, BACKLOG, WORKFLOW, DECISIONS).

## Validation
- Ran: `python3 -m compileall app`


