### PR TITLE
BPS-202: Add transaction audit log and admin audit table

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ Admin dashboard for managing billing records from a Google Sheet export.
 - Server-side DataTables endpoint (search, sort, pagination)
 - Filters: biller, transaction date range, due status
 - CRUD: create, edit, delete records
+- Transaction audit log for record state changes (create, update, delete, CSV import) with admin visibility
 - CSV import endpoint for bulk loading sheet exports
 - Duplicate detection by `txn_date + account + biller + amount` (create, update, import)
 - Auto-generated unique reference code when missing

--- a/app/database.py
+++ b/app/database.py
@@ -18,7 +18,7 @@ async def get_db() -> AsyncSession:
 
 
 async def init_db() -> None:
-    from app.models import BillRecord, BusinessProfile, UserAccount  # noqa: F401
+    from app.models import BillRecord, BusinessProfile, RecordAuditLog, UserAccount  # noqa: F401
 
     async with engine.begin() as conn:
         await conn.run_sync(SQLModel.metadata.create_all)

--- a/app/models/__init__.py
+++ b/app/models/__init__.py
@@ -1,6 +1,7 @@
 from app.models.auth_event_log import AuthEventLog
 from app.models.bill_record import BillRecord
 from app.models.business_profile import BusinessProfile
+from app.models.record_audit_log import RecordAuditLog
 from app.models.user_account import UserAccount
 
-__all__ = ["AuthEventLog", "BillRecord", "BusinessProfile", "UserAccount"]
+__all__ = ["AuthEventLog", "BillRecord", "BusinessProfile", "RecordAuditLog", "UserAccount"]

--- a/app/models/record_audit_log.py
+++ b/app/models/record_audit_log.py
@@ -1,0 +1,19 @@
+from datetime import datetime
+from typing import Optional
+
+from sqlmodel import Field, SQLModel
+
+
+class RecordAuditLog(SQLModel, table=True):
+    __tablename__ = "record_audit_logs"
+
+    id: Optional[int] = Field(default=None, primary_key=True)
+    record_id: Optional[int] = Field(default=None, index=True)
+    user_id: Optional[int] = Field(default=None, foreign_key="user_accounts.id", index=True)
+    actor_name: Optional[str] = Field(default=None, max_length=160)
+    actor_role: Optional[str] = Field(default=None, max_length=20, index=True)
+    action: str = Field(max_length=32, index=True)
+    channel: str = Field(max_length=32, index=True)
+    status: str = Field(max_length=20, index=True)
+    detail: Optional[str] = Field(default=None, max_length=255)
+    created_at: datetime = Field(default_factory=datetime.utcnow, nullable=False, index=True)

--- a/app/routes/bill_routes.py
+++ b/app/routes/bill_routes.py
@@ -30,7 +30,7 @@ from app.controllers.bill_controller import (
     update_record,
 )
 from app.database import get_db
-from app.models import BusinessProfile, UserAccount
+from app.models import BusinessProfile, RecordAuditLog, UserAccount
 
 router = APIRouter(tags=["bills"])
 templates = Jinja2Templates(directory="app/templates")
@@ -154,6 +154,37 @@ def _build_receipt_settings(profile: Optional[BusinessProfile]) -> dict:
         "show_cash": "cash" in visible,
         "show_change_amt": "change_amt" in visible,
     }
+
+
+def _actor_name(user: Optional[UserAccount]) -> str:
+    if not user:
+        return "SYSTEM"
+    return f"{user.first_name} {user.last_name}".strip() or user.phone
+
+
+async def _log_record_audit(
+    db: AsyncSession,
+    *,
+    action: str,
+    status: str,
+    current_user: Optional[UserAccount],
+    channel: str = "web",
+    record_id: Optional[int] = None,
+    detail: Optional[str] = None,
+) -> None:
+    db.add(
+        RecordAuditLog(
+            record_id=record_id,
+            user_id=current_user.id if current_user else None,
+            actor_name=_actor_name(current_user),
+            actor_role=current_user.role if current_user else "system",
+            action=action,
+            channel=channel,
+            status=status,
+            detail=detail,
+        )
+    )
+    await db.commit()
 
 
 @router.get("/admin/records", response_class=HTMLResponse, include_in_schema=False)
@@ -431,6 +462,36 @@ async def list_users(db: AsyncSession = Depends(get_db), _: UserAccount = Depend
     }
 
 
+@router.get("/api/admin/record-audit")
+async def list_record_audit_logs(
+    limit: int = Query(default=200, ge=1, le=1000),
+    db: AsyncSession = Depends(get_db),
+    _: UserAccount = Depends(require_admin),
+):
+    result = await db.execute(
+        select(RecordAuditLog)
+        .order_by(RecordAuditLog.created_at.desc(), RecordAuditLog.id.desc())
+        .limit(limit)
+    )
+    logs = result.scalars().all()
+    return {
+        "logs": [
+            {
+                "id": item.id,
+                "record_id": item.record_id,
+                "actor_name": item.actor_name or "",
+                "actor_role": item.actor_role or "",
+                "action": item.action,
+                "channel": item.channel,
+                "status": item.status,
+                "detail": item.detail or "",
+                "created_at": item.created_at.isoformat() if item.created_at else "",
+            }
+            for item in logs
+        ]
+    }
+
+
 @router.post("/api/admin/users")
 async def upsert_user(
     payload: AdminUserCreate,
@@ -544,21 +605,41 @@ async def receipt_page(
 async def create_record_endpoint(
     payload: RecordCreate,
     db: AsyncSession = Depends(get_db),
-    _: UserAccount = Depends(require_data_entry_access),
+    current_user: UserAccount = Depends(require_data_entry_access),
 ):
-    if payload.txn_datetime is None:
-        payload.txn_datetime = datetime.utcnow()
-    if payload.txn_date is None:
-        payload.txn_date = payload.txn_datetime.date()
+    try:
+        if payload.txn_datetime is None:
+            payload.txn_datetime = datetime.utcnow()
+        if payload.txn_date is None:
+            payload.txn_date = payload.txn_datetime.date()
 
-    if payload.due_date is None:
-        raise HTTPException(status_code=400, detail="Due date is required")
+        if payload.due_date is None:
+            raise HTTPException(status_code=400, detail="Due date is required")
 
-    if payload.bill_amt <= 0:
-        raise HTTPException(status_code=400, detail="Bill amount is required")
+        if payload.bill_amt <= 0:
+            raise HTTPException(status_code=400, detail="Bill amount is required")
 
-    record = await create_record(db, payload.model_dump())
-    return record
+        record = await create_record(db, payload.model_dump())
+        await _log_record_audit(
+            db,
+            action="create",
+            status="success",
+            current_user=current_user,
+            channel="api",
+            record_id=record.id,
+            detail=f"reference={record.reference or '-'}",
+        )
+        return record
+    except HTTPException as exc:
+        await _log_record_audit(
+            db,
+            action="create",
+            status="failed",
+            current_user=current_user,
+            channel="api",
+            detail=str(exc.detail),
+        )
+        raise
 
 
 @router.put("/api/records/{record_id}", response_model=RecordResponse)
@@ -566,38 +647,105 @@ async def update_record_endpoint(
     record_id: int,
     payload: RecordUpdate,
     db: AsyncSession = Depends(get_db),
-    _: UserAccount = Depends(require_admin),
+    current_user: UserAccount = Depends(require_admin),
 ):
-    updates = payload.model_dump(exclude_unset=True)
-    if not updates:
-        raise HTTPException(status_code=400, detail="No fields to update")
+    try:
+        updates = payload.model_dump(exclude_unset=True)
+        if not updates:
+            raise HTTPException(status_code=400, detail="No fields to update")
 
-    if "due_date" in updates and updates["due_date"] is None:
-        raise HTTPException(status_code=400, detail="Due date is required")
+        if "due_date" in updates and updates["due_date"] is None:
+            raise HTTPException(status_code=400, detail="Due date is required")
 
-    record = await update_record(db, record_id, updates)
-    return record
+        record = await update_record(db, record_id, updates)
+        await _log_record_audit(
+            db,
+            action="update",
+            status="success",
+            current_user=current_user,
+            channel="api",
+            record_id=record.id,
+            detail=f"reference={record.reference or '-'}",
+        )
+        return record
+    except HTTPException as exc:
+        await _log_record_audit(
+            db,
+            action="update",
+            status="failed",
+            current_user=current_user,
+            channel="api",
+            record_id=record_id,
+            detail=str(exc.detail),
+        )
+        raise
 
 
 @router.delete("/api/records/{record_id}", status_code=204)
 async def delete_record_endpoint(
     record_id: int,
     db: AsyncSession = Depends(get_db),
-    _: UserAccount = Depends(require_admin),
+    current_user: UserAccount = Depends(require_admin),
 ):
-    await delete_record(db, record_id)
-    return None
+    try:
+        record = await get_record(db, record_id)
+        reference = record.reference or "-"
+        await delete_record(db, record_id)
+        await _log_record_audit(
+            db,
+            action="delete",
+            status="success",
+            current_user=current_user,
+            channel="api",
+            record_id=record_id,
+            detail=f"reference={reference}",
+        )
+        return None
+    except HTTPException as exc:
+        await _log_record_audit(
+            db,
+            action="delete",
+            status="failed",
+            current_user=current_user,
+            channel="api",
+            record_id=record_id,
+            detail=str(exc.detail),
+        )
+        raise
 
 
 @router.post("/api/records/import-csv")
 async def import_csv_endpoint(
     file: UploadFile = File(...),
     db: AsyncSession = Depends(get_db),
-    _: UserAccount = Depends(require_admin),
+    current_user: UserAccount = Depends(require_admin),
 ):
-    if not file.filename.lower().endswith(".csv"):
-        raise HTTPException(status_code=400, detail="Please upload a CSV file")
+    try:
+        if not file.filename.lower().endswith(".csv"):
+            raise HTTPException(status_code=400, detail="Please upload a CSV file")
 
-    file_bytes = await file.read()
-    result = await import_csv_records(db, file_bytes)
-    return result
+        file_bytes = await file.read()
+        result = await import_csv_records(db, file_bytes)
+        await _log_record_audit(
+            db,
+            action="import_csv",
+            status="success",
+            current_user=current_user,
+            channel="csv_upload",
+            detail=(
+                f"created={result.get('created', 0)}, "
+                f"duplicates={result.get('duplicates', 0)}, "
+                f"skipped={result.get('skipped', 0)}"
+            ),
+        )
+        return result
+    except HTTPException as exc:
+        await _log_record_audit(
+            db,
+            action="import_csv",
+            status="failed",
+            current_user=current_user,
+            channel="csv_upload",
+            detail=str(exc.detail),
+        )
+        raise

--- a/app/static/css/app.css
+++ b/app/static/css/app.css
@@ -325,6 +325,11 @@ input[readonly] {
     text-transform: none;
 }
 
+.audit-grid td,
+.audit-grid th {
+    text-transform: none;
+}
+
 .mono {
     font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, "Liberation Mono", monospace;
     letter-spacing: 0.2px;
@@ -349,6 +354,27 @@ input[readonly] {
     background: #edf7ea;
     color: #235b2a;
     border: 1px solid #cfe9cc;
+}
+
+.status-pill {
+    display: inline-block;
+    padding: 0.15rem 0.45rem;
+    border-radius: 999px;
+    font-size: 0.75rem;
+    font-weight: 700;
+    text-transform: uppercase;
+}
+
+.status-success {
+    background: #e9f9ee;
+    color: #1e6a33;
+    border: 1px solid #c9ebd4;
+}
+
+.status-failed {
+    background: #fff0f0;
+    color: #8c1d1d;
+    border: 1px solid #ffd0d0;
 }
 
 .entry-form {

--- a/app/static/js/records.js
+++ b/app/static/js/records.js
@@ -27,6 +27,12 @@ function round2(value) {
     return Math.round((parseNum(value) + Number.EPSILON) * 100) / 100;
 }
 
+function formatStatusPill(value) {
+    const status = String(value || "").toLowerCase();
+    const cls = status === "success" ? "status-success" : "status-failed";
+    return `<span class="status-pill ${cls}">${status || "-"}</span>`;
+}
+
 function showMessage(message, title = "Notice") {
     const dialog = document.getElementById("appMessageDialog");
     const titleEl = document.getElementById("appMessageTitle");
@@ -241,6 +247,36 @@ const table = new DataTable("#recordsTable", {
     order: [[1, "desc"]],
 });
 
+const auditTableEl = document.getElementById("auditTable");
+const auditTableInstance = auditTableEl
+    ? new DataTable("#auditTable", {
+        processing: true,
+        ajax: {
+            url: "/api/admin/record-audit",
+            dataSrc: "logs",
+        },
+        pageLength: 10,
+        autoWidth: false,
+        columns: [
+            { data: "created_at", render: formatDateTime },
+            { data: "actor_name", render: (d) => d || "-" },
+            { data: "actor_role", render: (d) => d || "-" },
+            { data: "action", render: (d) => String(d || "").toUpperCase() },
+            { data: "channel", render: (d) => String(d || "").toUpperCase() },
+            { data: "status", render: formatStatusPill },
+            { data: "record_id", render: (d) => (d == null ? "-" : d) },
+            { data: "detail", render: (d) => d || "" },
+        ],
+        order: [[0, "desc"]],
+    })
+    : null;
+
+function reloadAuditLog() {
+    if (auditTableInstance) {
+        auditTableInstance.ajax.reload(null, false);
+    }
+}
+
 const usersDialog = document.getElementById("usersDialog");
 const openUsersBtn = document.getElementById("openUsersBtn");
 const closeUsersBtn = document.getElementById("closeUsersBtn");
@@ -430,10 +466,12 @@ async function removeRecord(id) {
     const response = await fetch(`/api/records/${id}`, { method: "DELETE" });
     if (!response.ok) {
         await showMessage("Delete failed. Please try again.", "Delete Failed");
+        reloadAuditLog();
         return;
     }
 
     table.ajax.reload(null, false);
+    reloadAuditLog();
 }
 
 function payloadFromForm() {
@@ -516,11 +554,13 @@ async function saveRecord(event) {
         } else {
             await showMessage(err.detail || "Save failed.", "Save Failed");
         }
+        reloadAuditLog();
         return;
     }
 
     dom.dialog.close();
     table.ajax.reload(null, false);
+    reloadAuditLog();
 }
 
 async function importCsv(event) {
@@ -547,12 +587,14 @@ async function importCsv(event) {
 
     if (!response.ok) {
         statusEl.textContent = "Import failed";
+        reloadAuditLog();
         return;
     }
 
     const result = await response.json();
     statusEl.textContent = `Imported ${result.created}, duplicates ${result.duplicates || 0}, skipped ${result.skipped}`;
     table.ajax.reload();
+    reloadAuditLog();
     fileInput.value = "";
 }
 
@@ -574,6 +616,11 @@ document.getElementById("clearFiltersBtn").addEventListener("click", () => {
     filters.dueStatus.value = "";
     table.search("").draw();
 });
+
+const refreshAuditBtn = document.getElementById("refreshAuditBtn");
+if (refreshAuditBtn) {
+    refreshAuditBtn.addEventListener("click", reloadAuditLog);
+}
 
 Object.values(filters).forEach((el) => {
     el.addEventListener("change", () => table.ajax.reload());

--- a/app/templates/records.html
+++ b/app/templates/records.html
@@ -86,6 +86,29 @@
     </table>
 </section>
 
+<section class="panel">
+    <div class="panel-head">
+        <h2>Transaction Audit Log</h2>
+    </div>
+    <div class="dialog-actions">
+        <button type="button" class="btn btn-secondary" id="refreshAuditBtn">Refresh Audit Log</button>
+    </div>
+    <table id="auditTable" class="display audit-grid" style="width:100%">
+        <thead>
+            <tr>
+                <th>When</th>
+                <th>Who</th>
+                <th>Role</th>
+                <th>Action</th>
+                <th>Channel</th>
+                <th>Status</th>
+                <th>Record ID</th>
+                <th>Detail</th>
+            </tr>
+        </thead>
+    </table>
+</section>
+
 <dialog id="usersDialog" class="record-dialog users-dialog">
     <div class="dialog-head">
         <h3>Users</h3>

--- a/app/templates/signin.html
+++ b/app/templates/signin.html
@@ -2,7 +2,9 @@
 
 {% block title %}Sign In | Bills Admin{% endblock %}
 {% block topbar_title %}Welcome Back{% endblock %}
-{% block topbar_subtitle %}Sign in with your phone number and 4-digit PIN.{% endblock %}
+{% block topbar_subtitle %}
+Sign in with your phone number and 4-digit PIN. After several failed attempts, your account will be temporarily locked for your security.
+{% endblock %}
 {% block topbar_actions %}
 <a class="btn btn-secondary" href="/auth/signup">Sign Up</a>
 {% endblock %}
@@ -19,6 +21,10 @@
     {% if success %}
     <div class="alert-success">{{ success }}</div>
     {% endif %}
+
+    <p class="auth-hint">
+        Tip: If your account becomes locked after too many failed attempts, use <strong>Forgot PIN</strong> to reset via OTP.
+    </p>
 
     <form method="post" action="/auth/signin" class="auth-form">
         <label>Phone Number

--- a/app/templates/signup.html
+++ b/app/templates/signup.html
@@ -2,7 +2,9 @@
 
 {% block title %}Sign Up | Bills Admin{% endblock %}
 {% block topbar_title %}Create Account{% endblock %}
-{% block topbar_subtitle %}Register with your name, phone number, and 4-digit PIN.{% endblock %}
+{% block topbar_subtitle %}
+Register with your name, phone number, and 4-digit PIN. We will send a one-time OTP to verify your phone before activating your account.
+{% endblock %}
 {% block topbar_actions %}
 <a class="btn btn-secondary" href="/auth/signin">Sign In</a>
 {% endblock %}
@@ -16,6 +18,10 @@
     {% if error %}
     <div class="alert-error">{{ error }}</div>
     {% endif %}
+
+    <p class="auth-hint">
+        After submitting this form, check your phone for an OTP code to complete signup.
+    </p>
 
     <form method="post" action="/auth/signup" class="auth-form">
         <label>First Name

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -12,7 +12,7 @@
   - [x] BPS-201.8 Auth logging: log signin success/failure, lockout events, OTP verify events
   - [ ] BPS-201.9 UI updates: signup/signin templates show OTP and lockout states with clear errors
   - [ ] BPS-201.10 Verification: manual test matrix for happy path, invalid OTP, expired OTP, lockout, reset flow
-- [ ] BPS-202 | Theme: Reliability | Outcome: Add transaction audit log (`who`, `when`, `channel`, `status`) | Done when: each record state change writes an audit entry and is viewable in admin
+- [x] BPS-202 | Theme: Reliability | Outcome: Add transaction audit log (`who`, `when`, `channel`, `status`) | Done when: each record state change writes an audit entry and is viewable in admin
 - [ ] BPS-203 | Theme: Validation | Outcome: Strengthen counter payment validation by biller rules | Done when: required fields/format are enforced per biller before save
 
 ## NEXT
@@ -30,3 +30,4 @@
 - [x] BPS-102 | Shipped on: 2026-03-05 | Notes: Dashboard/records view with filters and CRUD
 - [x] BPS-103 | Shipped on: 2026-03-05 | Notes: Duplicate detection (`date + account + biller + amount`)
 - [x] BPS-104 | Shipped on: 2026-03-06 | Notes: Auto reference generation + receipt print view
+- [x] BPS-202 | Shipped on: 2026-03-09 | Notes: Record audit trail with admin audit table (`who/when/channel/status`, plus action/detail)

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -10,7 +10,7 @@
   - [x] BPS-201.6 Signin controls: add failed-attempt counter and temporary lockout after threshold
   - [x] BPS-201.7 Recovery flow: add PIN reset request + OTP confirm + new PIN set
   - [x] BPS-201.8 Auth logging: log signin success/failure, lockout events, OTP verify events
-  - [ ] BPS-201.9 UI updates: signup/signin templates show OTP and lockout states with clear errors
+  - [x] BPS-201.9 UI updates: signup/signin templates show OTP and lockout states with clear errors
   - [x] BPS-201.10 Verification: manual test matrix for happy path, invalid OTP, expired OTP, lockout, reset flow (see `docs/AUTH_TEST_MATRIX.md`)
 - [x] BPS-202 | Theme: Reliability | Outcome: Add transaction audit log (`who`, `when`, `channel`, `status`) | Done when: each record state change writes an audit entry and is viewable in admin
 - [ ] BPS-203 | Theme: Validation | Outcome: Strengthen counter payment validation by biller rules | Done when: required fields/format are enforced per biller before save

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -30,3 +30,11 @@ Track meaningful technical and product decisions so future changes stay consiste
 - Why: The PDF captures business intent, risks, and sequencing better than generic placeholders.
 - Alternatives considered: continue with placeholder backlog, or prioritize by technical ease only.
 - Follow-up: Re-rank `NOW/NEXT/LATER` every Friday based on incident risk, reconciliation impact, and operational speed.
+
+- Date: 2026-03-09
+- ID: DEC-004
+- Related task: BPS-202
+- Decision: Add a dedicated `record_audit_logs` table and log record state changes (`create`, `update`, `delete`, `import_csv`) from route handlers with actor, channel, status, and detail metadata.
+- Why: We need traceability of operational changes directly in admin tooling without relying on external logs.
+- Alternatives considered: reusing auth event logs table, filesystem logs only, no UI exposure.
+- Follow-up: Expand audit coverage to future record status transitions and add filter/search controls on the audit table if volume grows.


### PR DESCRIPTION
## Summary
- Added `record_audit_logs` model/table to track record state changes.
- Logged audit events for record actions:
  - create
  - update
  - delete
  - CSV import
- Captured audit metadata:
  - actor (`who`)
  - timestamp (`when`)
  - channel (`api`/`csv_upload`)
  - status (`success`/`failed`)
  - action + detail
- Added admin endpoint: `GET /api/admin/record-audit`.
- Added Transaction Audit Log table to admin records page with refresh action.
- Updated docs (`README`, `BACKLOG`, `DECISIONS`) to reflect BPS-202 completion.

## Validation
- Ran: `python3 -m compileall app`
